### PR TITLE
Do not exclude reversibility changes or spontaneous reactions from gapfill

### DIFF
--- a/src/MFAProblem.cpp
+++ b/src/MFAProblem.cpp
@@ -6086,9 +6086,13 @@ int MFAProblem::LoadGapFillingReactions(Data* InData, OptimizationParameter* InP
 			}
 			  
 			//Test status for OK flag
-			if(AddReaction && rxnobj->get("status").length() >= 2 && rxnobj->get("status").substr(0,2).compare("OK") != 0){
-			  cout << "Status for reaction " << RxnId << " not OK: " << rxnobj->get("status") << endl;
-			  AddReaction = false;
+			if(AddReaction && rxnobj->get("status").length() >= 2) {
+			  string stat = rxnobj->get("status").substr(0,2);
+			  //RC, FO, SP, UN and RO statuses (Reversibility corrections and spontaneous reactions) are always accompanied by an "OK" status
+			  if(! (stat.compare("OK") == 0 || stat.compare("RC") == 0 || stat.compare("FO") == 0 || stat.compare("RO") == 0 || stat.compare("SP") == 0 || stat.compare("UN") == 0) ) {
+			    cout << "Status for reaction " << RxnId << " not OK: " << rxnobj->get("status") << endl;
+			    AddReaction = false;
+			  }
 			}
 
 			if(AddReaction){


### PR DESCRIPTION
This one we should probably talk about before you pull it. It assumes that RC, SP, etc. should also be included as gapfillable reactions since they are in fact mass and charge balanced.
